### PR TITLE
Instanced shadows

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ export default e => {
         physics,
       });
       terrainMesh.frustumCulled = false;
-      // terrainMesh.castShadow = true;
+      // ! terrainMesh.castShadow = true;
       terrainMesh.receiveShadow = true;
       app.add(terrainMesh);
       terrainMesh.updateMatrixWorld();
@@ -111,12 +111,12 @@ export default e => {
     barrierMesh.updateMatrixWorld(); */
 
       const TERRAIN_OBJECTS_MESHES = {
-        treeMesh: new TerrainObjectSpecs(InstancedObjectMesh, treeUrls),
-        bushMesh: new TerrainObjectSpecs(InstancedObjectMesh, bushUrls),
-        rockMesh: new TerrainObjectSpecs(InstancedObjectMesh, rockUrls),
-        stoneMesh: new TerrainObjectSpecs(InstancedObjectMesh, stoneUrls),
-        grassMesh: new TerrainObjectSpecs(GrassMesh, grassUrls),
-        hudMesh: new TerrainObjectSpecs(HudMesh, hudUrls),
+        treeMesh: new TerrainObjectSpecs(InstancedObjectMesh, treeUrls, true),
+        bushMesh: new TerrainObjectSpecs(InstancedObjectMesh, bushUrls, true),
+        rockMesh: new TerrainObjectSpecs(InstancedObjectMesh, rockUrls, true),
+        stoneMesh: new TerrainObjectSpecs(InstancedObjectMesh, stoneUrls, false),
+        grassMesh: new TerrainObjectSpecs(GrassMesh, grassUrls, false),
+        hudMesh: new TerrainObjectSpecs(HudMesh, hudUrls, false),
       };
 
       const terrainObjects = new TerrainObjectsMesh(

--- a/layers/instanced-object-mesh.js
+++ b/layers/instanced-object-mesh.js
@@ -35,7 +35,7 @@ const maxDrawCallsPerGeometry = 256;
 //
 
 export class InstancedObjectMesh extends THREE.Object3D {
-  constructor({instance, physics, urls}) {
+  constructor({instance, physics, urls, shadow}) {
     super();
 
     this.urls = urls;
@@ -46,6 +46,7 @@ export class InstancedObjectMesh extends THREE.Object3D {
       maxNumGeometries,
       maxInstancesPerGeometryPerDrawCall,
       maxDrawCallsPerGeometry,
+      shadow
     });
     this.add(this.polygonMesh);
 

--- a/meshes/terrain-objects-mesh.js
+++ b/meshes/terrain-objects-mesh.js
@@ -1,9 +1,10 @@
 import * as THREE from "three";
 
 export class TerrainObjectSpecs {
-  constructor(constructor, urls) {
+  constructor(constructor, urls, shadow) {
     this.construct = constructor;
     this.urls = urls;
+    this.shadow = shadow;
   }
 }
 export class TerrainObjectsMesh extends THREE.Object3D {
@@ -16,6 +17,7 @@ export class TerrainObjectsMesh extends THREE.Object3D {
         instance,
         physics,
         urls: meshSpecs.urls,
+        shadow: meshSpecs.shadow
       });
       this.add(mesh);
       mesh.updateMatrixWorld();


### PR DESCRIPTION
### Shadows for instanced objects
This PR adds shadows for instanced objects of procgen
### Implementation
Since we're using custom shaders for instancing and we're changing the positions in the vertex shader, we need to also use `customDepthMaterial` ( for `DirectionalLight` and `SpotLight` ) and `customDistanceMaterial` ( for `PointLight` ).
#### Useful Links : 
https://threejs.org/docs/#api/en/materials/MeshDistanceMaterial
https://threejs.org/docs/#api/en/core/Object3D.customDepthMaterial
https://threejs.org/docs/#api/en/core/Object3D.customDistanceMaterial
https://discourse.threejs.org/t/shadow-for-instances/7947/10